### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pattern.
 
 ```go
 handler := bus.Handler{
-    Handle: func(e *Event) {
+    Handle: func(e *bus.Event) {
         // do something
         // NOTE: Highly recommended to process the event in an async way
     },


### PR DESCRIPTION
Prefixes the Event interface name with the `bus` package name as this is needed if copy/pasting from the provided example snippets.